### PR TITLE
Adds plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  singleQuote: true,
+  bracketSpacing: false,
+  trailingComma: 'es5',
+};

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
-# docusaurus
+# @papercups-io/docusaurus
+
+This plugins enable usage of the Papercups chat widget on Docusaurus powered websites.
+
+## Install
+
+```
+npm install --save @papercups-io/docusaurus
+```
+
+## Usage
+
+1. Sign up at https://app.papercups.io/register to get your account token. Your account token is what you will use to pass in as the accountId prop below.
+
+2. Configure the plugin in `docusaurus.config.js`:
+
+```
+// docusaurus.config.js
+module.exports = {
+  plugins: [
+    [
+      "@papercups-io/docusaurus-plugin",
+      {
+        /* REQUIRED */
+        // Pass in your Papercups account token here after signing up
+        accountId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx',
+
+        /* OPTIONAL */
+        title: 'Welcome to Papercups!',
+        subtitle: 'Ask us anything in the chat window below 😊',
+        newMessagePlaceholder: 'Start typing...',
+        primaryColor: '#13c2c2',
+
+        // Initial message that new users will see.
+        greeting: 'Hi there! How can I help you?',
+
+        // Used only when self-hosting Papercups. Otherwise leave it empty.
+        baseUrl: 'https://app.papercups.io',
+
+        // Add this if you want to require the customer to enter
+        // their email before being able to send you a message
+        requireEmailUpfront: true,
+
+        // Add this if you want to indicate when you/your agents
+        // are online or offline to your customers
+        showAgentAvailability: true,
+      },
+    ],
+  ],
+};
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "docusaurus",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "docusaurus",
+  "version": "1.0.0",
+  "description": "Papercups plugin for docusaurus",
+  "main": "src/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/papercups-io/docusaurus.git"
+  },
+  "keywords": [
+    "docusaurus",
+    "papercups"
+  ],
+  "author": "Rob Honsby",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/papercups-io/docusaurus/issues"
+  },
+  "homepage": "https://github.com/papercups-io/docusaurus#readme"
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,74 @@
+module.exports = function (_context, options) {
+  const {
+    accountId,
+    baseUrl = "https://app.papercups.io",
+    greeting,
+    newMessagePlaceholder,
+    primaryColor = "#1890ff",
+    requireEmailUpfront,
+    showAgentAvailability,
+    subtitle,
+    title,
+  } = options;
+
+  // Removes the non-nullish values to condense the injected html.
+  const config = Object.entries({
+    accountId,
+    baseUrl,
+    greeting,
+    newMessagePlaceholder,
+    primaryColor,
+    requireEmailUpfront,
+    showAgentAvailability,
+    subtitle,
+    title,
+  })
+    .filter((_key, value) => value != null)
+    .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {});
+
+  if (!accountId) {
+    throw new Error(`'accountId' missing in plugin options.`);
+  }
+
+  return {
+    name: "@papercups-io/docusaurus",
+    injectHtmlTags() {
+      return {
+        postBodyTags: [
+          {
+            tagName: "script",
+            attributes: {
+              type: "text/javascript",
+            },
+            innerHTML: `window.Papercups={config:${JSON.stringify(config)}};`,
+          },
+          // When the window's width is 996px and below, docusaurus has a sidebar button.
+          // These styles moves the chat toggle button above it to prevent the two buttons from overlapping.
+          {
+            tagName: "style",
+            innerHTML: `
+              @media (max-width: 996px) {
+                .Papercups-toggleButtonContainer {
+                  bottom: 80px;
+                }
+
+                .Papercups-chatWindowContainer {
+                  bottom: 160px;
+                }
+              }
+            `,
+          },
+          {
+            tagName: "script",
+            attributes: {
+              type: "text/javascript",
+              async: true,
+              defer: true,
+              src: `${baseUrl}/widget.js`,
+            },
+          },
+        ],
+      };
+    },
+  };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,50 @@
 module.exports = function (_context, options) {
   const {
     accountId,
-    baseUrl = "https://app.papercups.io",
+    agentAvailableText,
+    agentUnavailableText,
+    awayMessage,
+    baseUrl = 'https://app.papercups.io',
+    customer,
+    customIconUrl,
+    defaultIsOpen,
+    emailInputPlaceholder,
     greeting,
+    hideToggleButton,
+    iconVariant,
+    iframeUrlOverride,
+    isOpenByDefault,
     newMessagePlaceholder,
-    primaryColor = "#1890ff",
+    newMessagesNotificationText,
+    persistOpenState,
+    position,
+    primaryColor = '#1890ff',
     requireEmailUpfront,
     showAgentAvailability,
     subtitle,
     title,
   } = options;
 
-  // Removes the non-nullish values to condense the injected html.
+  // Removes the nullish values to condense the injected html.
   const config = Object.entries({
     accountId,
+    agentAvailableText,
+    agentUnavailableText,
+    awayMessage,
     baseUrl,
+    customer,
+    customIconUrl,
+    defaultIsOpen,
+    emailInputPlaceholder,
     greeting,
+    hideToggleButton,
+    iconVariant,
+    iframeUrlOverride,
+    isOpenByDefault,
     newMessagePlaceholder,
+    newMessagesNotificationText,
+    persistOpenState,
+    position,
     primaryColor,
     requireEmailUpfront,
     showAgentAvailability,
@@ -24,28 +52,28 @@ module.exports = function (_context, options) {
     title,
   })
     .filter((_key, value) => value != null)
-    .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {});
+    .reduce((acc, [key, value]) => ({...acc, [key]: value}), {});
 
   if (!accountId) {
     throw new Error(`'accountId' missing in plugin options.`);
   }
 
   return {
-    name: "@papercups-io/docusaurus",
+    name: '@papercups-io/docusaurus',
     injectHtmlTags() {
       return {
         postBodyTags: [
           {
-            tagName: "script",
+            tagName: 'script',
             attributes: {
-              type: "text/javascript",
+              type: 'text/javascript',
             },
             innerHTML: `window.Papercups={config:${JSON.stringify(config)}};`,
           },
           // When the window's width is 996px and below, docusaurus has a sidebar button.
           // These styles moves the chat toggle button above it to prevent the two buttons from overlapping.
           {
-            tagName: "style",
+            tagName: 'style',
             innerHTML: `
               @media (max-width: 996px) {
                 .Papercups-toggleButtonContainer {
@@ -59,9 +87,9 @@ module.exports = function (_context, options) {
             `,
           },
           {
-            tagName: "script",
+            tagName: 'script',
             attributes: {
-              type: "text/javascript",
+              type: 'text/javascript',
               async: true,
               defer: true,
               src: `${baseUrl}/widget.js`,


### PR DESCRIPTION
This is the initial commit that has everything needed to enable the Papercups chat widget on docusaurus powered websites.

## Test plan
With a local copy of `papercups-io/docs`, add the plugin to `docusaurus.config.js`:
```
  module.exports = {
    plugins: [
      [
        path.resolve(__dirname, '../docusaurus/src'),
        {accountId: 'eb504736-0f20-4978-98ff-1a82ae60b266'},
      ],
    ],
  };
```

Then run `npm run build && npm run start`. 

https://i.imgur.com/ZHKvy0W.mp4